### PR TITLE
host not found in upstream "web:3000"エラーによりタスク定義のコンテナ名を修正

### DIFF
--- a/.aws-terraform/task-definition.json
+++ b/.aws-terraform/task-definition.json
@@ -8,7 +8,7 @@
   "memory": "512",
   "containerDefinitions": [
     {
-      "name": "rails",
+      "name": "web",
       "image": "${rails_ecr_repo_uri}",
       "cpu": 128,
       "memory": 256,


### PR DESCRIPTION
１　nginxとタスク定義でコンテナ名を統一