### PR TITLE
host not found in upstream "web:3000"によりserverを修正

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -4,7 +4,7 @@ events {
 
 http {
   upstream myapp {
-    server web:3000;
+    server localhost:3000;
     keepalive 64;
   }
 


### PR DESCRIPTION
１　host not found in upstream "web:3000"エラーが続いてるため、nginx.confファイルを修正