### PR TITLE
connect() failedエラーのためupstreamディレクトリを修正

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -4,7 +4,7 @@ events {
 
 http {
   upstream myapp {
-    server localhost:3000;
+    server 127.0.0.1:3000;
     keepalive 64;
   }
 


### PR DESCRIPTION
１　connect() failedエラーがnginxのsevserでlocalhostを設定していることが原因と推測し修正