### PR TITLE
nginxへのヘルスチェックを変え、Fargateでの500エラーに対応

### DIFF
--- a/.aws-terraform/task-definition.json
+++ b/.aws-terraform/task-definition.json
@@ -73,7 +73,7 @@
         }
       ],
       "healthCheck": {
-        "command":  ["CMD-SHELL","curl -f http://localhost/ || exit 1"],
+        "command":  ["CMD-SHELL","curl -f http://localhost/health || exit 1"],
         "interval": 30,
         "timeout": 5,
         "retries": 3,


### PR DESCRIPTION
１　タスク定義でnginxへのヘルスチェックURIを変えていなかったためFargateにて500エラーが起きたと推測し、修正