### PR TITLE
Fargateのnginxコンテナ内でroot下にpublicディレクトリが存在しなかったため修正

### DIFF
--- a/.nginx/dockerfile
+++ b/.nginx/dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY ./myapp /myapp
 
 CMD /usr/sbin/nginx -g 'daemon off;' -c /etc/nginx/nginx.conf


### PR DESCRIPTION
１　Fargateのnginxコンテナ内でroot下にpublicディレクトリが存在しなかったため修正