### PR TITLE
publicディレクトリ下がコピーされていなかった為、再度dockerfileのパスを修正

### DIFF
--- a/.nginx/dockerfile
+++ b/.nginx/dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY ./ /myapp/
+COPY ./public /myapp/public
 
 CMD /usr/sbin/nginx -g 'daemon off;' -c /etc/nginx/nginx.conf


### PR DESCRIPTION
１　publicディレクトリ下がコピーされていなかった為、再度dockerfileのパスを修正