### PR TITLE
publicディレクトリのパス指定エラーのため修正

### DIFF
--- a/.nginx/dockerfile
+++ b/.nginx/dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY ./public /myapp/public
+COPY ./../public /myapp/public
 
 CMD /usr/sbin/nginx -g 'daemon off;' -c /etc/nginx/nginx.conf


### PR DESCRIPTION
１　publicディレクトリのパス指定エラーのためNginxのdockerfileを修正